### PR TITLE
Fix compiler errors in examples and add new widget.

### DIFF
--- a/examples/course.ur
+++ b/examples/course.ur
@@ -122,7 +122,7 @@ structure GlobalForum = GlobalDiscussion.Make(struct
 
                                                val showOpenVsClosed = True
                                                val allowPrivate = True
-                                               fun onNewMessage r = debug ("New GLOBAL message in " ^ r.Subject ^ ": " ^ r.Text)
+                                               fun onNewMessage _ r = debug ("New GLOBAL message in " ^ r.Subject ^ ": " ^ r.Text)
                                            end)
 
 table pset : { PsetNum : int, Released : time, Due : time, GradesDue : time, Instructions : string, Czar : option string }
@@ -247,7 +247,7 @@ structure PsetCal = Calendar.FromTable(struct
                                                    set content (Ui.simpleModal
                                                                     <xml>
                                                                       <h2>Pset #{[r.PsetNum]}</h2>
-                                                                      
+
                                                                       <button class="btn btn-primary"
                                                                               onclick={fn _ =>
                                                                                           xm <- PsetSub.newUpload r;
@@ -258,7 +258,7 @@ structure PsetCal = Calendar.FromTable(struct
                                                                       <hr/>
 
                                                                       <h2>Instructions</h2>
-                                                                      
+
                                                                       {Widget.html ps.Instructions}
                                                                     </xml>
                                                                     <xml>Close</xml>)
@@ -267,7 +267,7 @@ structure PsetCal = Calendar.FromTable(struct
                                                     set content (Ui.simpleModal
                                                                      <xml>
                                                                        <h2>Pset #{[r.PsetNum]}</h2>
-                                                                       
+
                                                                        {xm}
                                                                      </xml>
                                                                      <xml>Close</xml>));
@@ -319,12 +319,12 @@ structure PsetForum = TableDiscussion.Make(struct
 
                                                val showOpenVsClosed = True
                                                val allowPrivate = True
-                                               fun onNewMessage r = debug ("New message in " ^ r.Subject ^ ": " ^ r.Text)
+                                               fun onNewMessage _ r = debug ("New message in " ^ r.Subject ^ ": " ^ r.Text)
                                            end)
 
 fun psetInfo n =
     ps <- getPset n;
-    
+
     Theme.simple ("Pset #" ^ show n)
               (Ui.seq
                    (Ui.constM (fn ctx => <xml>

--- a/examples/mg.ur
+++ b/examples/mg.ur
@@ -75,7 +75,8 @@ val main = Theme.simple "MG"
                            </xml>))
 
 val mainRev = Theme.simple "MG"
-                        S.Away.FullGrid.ui
+                           (S.Away.FullGrid.ui (fn {Company = _, EmployeeId = _, Something = _, SomethingElse = _} =>
+                                                   return True))
 
 fun away s =
     case read s of

--- a/examples/rsv.ur
+++ b/examples/rsv.ur
@@ -52,6 +52,8 @@ structure S = Rsvp2.Make(struct
                              val amHome = getCookie homeC
                              val amPrivilegedHome = amHome
                              val amAway = getCookie awayC
+
+                             fun render {Description = d} = txt d
                          end)
 
 fun home s =

--- a/widget.ur
+++ b/widget.ur
@@ -141,6 +141,38 @@ val htmlbox = { Configure = return (),
                 Value = Ckeditor.content,
                 AsValue = html }
 
+type choicebox (a :: Type) =
+    { Choices : list a,
+      Source : source string }
+
+type choicebox_config (a :: Type) = list a
+
+fun choicebox [a ::: Type] (_ : show a) (_ : read a) (choice : a) (choices : list a) =
+    { Configure = return (choice :: choices),
+      Create = fn ls =>
+                  s <- source (show choice);
+                  return {Choices = ls, Source = s},
+      Initialize = fn ls v =>
+                      s <- source (show v);
+                      return {Choices = ls, Source = s},
+      Reset = fn me => set me.Source (show choice),
+      AsWidget = fn me id =>
+                    let
+                        val inner = <xml>
+                          {List.mapX (fn v => <xml><coption>{[v]}</coption></xml>) me.Choices}
+                        </xml>
+                    in
+                        case id of
+                            None => <xml><cselect class={Bootstrap3.form_control} source={me.Source}>{inner}</cselect></xml>
+                          | Some id => <xml><cselect class={Bootstrap3.form_control} id={id} source={me.Source}>{inner}</cselect></xml>
+                    end,
+      Value = fn me =>
+                 s <- signal me.Source;
+                 return (case read s of
+                             None => choice
+                           | Some v => v),
+      AsValue = txt }
+
 type foreignbox (a :: Type) =
     { Choices : list a,
       Source : source string }

--- a/widget.ur
+++ b/widget.ur
@@ -149,10 +149,10 @@ type choicebox_config (a :: Type) = unit
 
 fun choicebox [a ::: Type] (_ : show a) (_ : read a) (choice : a) (choices : list a) =
     { Configure = return (),
-      Create = fn ls =>
+      Create = fn () =>
                   s <- source (show choice);
                   return {Choices = choice :: choices, Source = s},
-      Initialize = fn ls v =>
+      Initialize = fn () v =>
                       s <- source (show v);
                       return {Choices = choice :: choices, Source = s},
       Reset = fn me => set me.Source (show choice),

--- a/widget.ur
+++ b/widget.ur
@@ -145,16 +145,16 @@ type choicebox (a :: Type) =
     { Choices : list a,
       Source : source string }
 
-type choicebox_config (a :: Type) = list a
+type choicebox_config (a :: Type) = unit
 
 fun choicebox [a ::: Type] (_ : show a) (_ : read a) (choice : a) (choices : list a) =
-    { Configure = return (choice :: choices),
+    { Configure = return (),
       Create = fn ls =>
                   s <- source (show choice);
-                  return {Choices = ls, Source = s},
+                  return {Choices = choice :: choices, Source = s},
       Initialize = fn ls v =>
                       s <- source (show v);
-                      return {Choices = ls, Source = s},
+                      return {Choices = choice :: choices, Source = s},
       Reset = fn me => set me.Source (show choice),
       AsWidget = fn me id =>
                     let

--- a/widget.urs
+++ b/widget.urs
@@ -57,6 +57,14 @@ type timebox
 type timebox_config
 val timebox : t time timebox timebox_config
 
+con choicebox :: Type -> Type
+con choicebox_config :: Type -> Type
+val choicebox : a ::: Type ->
+                 show a
+                 -> read a
+                 -> a -> list a
+                 -> t a (choicebox a) (choicebox_config a)
+
 (* A widget that only allows selection from a finite list, computed via an SQL query *)
 con foreignbox :: Type -> Type
 con foreignbox_config :: Type -> Type


### PR DESCRIPTION
Does what it says on the tin. The new widget is `choicebox`, which is like `foreignbox_default` but with a constant list of choices.
