### PR TITLE
Ui.modalAnchor (counterpart to Ui.modalButton)

### DIFF
--- a/ui.ur
+++ b/ui.ur
@@ -212,6 +212,17 @@ fun modalButton ctx cls bod onclick = <xml>
   </button>
 </xml>
 
+fun modalAnchor ctx cls bod onclick = <xml>
+  <a class={cls}
+     data-toggle="modal"
+     data-target={"#" ^ show ctx.ModalId}
+     onclick={fn _ =>
+                 ms <- onclick;
+                 set ctx.ModalSpot ms}>
+    {bod}
+  </a>
+</xml>
+
 fun modal bcode titl bod blab = <xml>
   <div class="modal-dialog">
     <div class="modal-content">

--- a/ui.urs
+++ b/ui.urs
@@ -83,6 +83,13 @@ val modalButton : context
                   -> transaction xbody (* content of modal dialog *)
                   -> xbody
 
+(* The same, but uses <a> instead of <button>. Useful for button dropdowns. *)
+val modalAnchor : context
+                  -> css_class         (* additional styling *)
+                  -> xbody             (* text label *)
+                  -> transaction xbody (* content of modal dialog *)
+                  -> xbody
+
 (* A standard template for creating the modal form *)
 val modal : transaction unit     (* callback on clicking main button *)
             -> xbody             (* main prompt *)


### PR DESCRIPTION
There is at least one context (button dropdowns) in which one needs to use `<a>` rather than `<button>`.
