### PR TITLE
Allow arbitrarily many CSS URLs in Ui.THEME.

### DIFF
--- a/cached.ur
+++ b/cached.ur
@@ -1,3 +1,5 @@
-val bootstrap = bless "/bootstrap.min.css"
-val custom = bless "/style.css"
+val css =
+    {Bootstrap = bless "/bootstrap.min.css",
+     Upo = bless "/style.css"}
+
 val icon = None

--- a/cached.urs
+++ b/cached.urs
@@ -1,1 +1,1 @@
-include Ui.THEME
+include Ui.THEME with con r = [Bootstrap, Upo]

--- a/default.ur
+++ b/default.ur
@@ -1,3 +1,5 @@
-val bootstrap = bless "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
-val custom = bless "/style.css"
+val css =
+    {Bootstrap = bless "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css",
+     Upo = bless "/style.css"}
+
 val icon = None

--- a/default.urs
+++ b/default.urs
@@ -1,1 +1,1 @@
-include Ui.THEME
+include Ui.THEME where con r = [Bootstrap, Upo]

--- a/ui.ur
+++ b/ui.ur
@@ -67,8 +67,9 @@ fun constM bod = {
 }
 
 signature THEME = sig
-    val bootstrap : url
-    val custom : url
+    con r :: {Unit}
+    val fl : folder r
+    val css : $(mapU url r)
     val icon : option url
 end
 
@@ -81,8 +82,10 @@ functor Make(M : THEME) = struct
         return <xml>
           <head>
             <title>{[titl]}</title>
-            <link rel="stylesheet" href={M.bootstrap}/>
-            <link rel="stylesheet" href={M.custom}/>
+            {@mapUX [url] [_]
+              (fn [nm ::_] [rest ::_] [_~_] url =>
+                  <xml><link rel="stylesheet" href={url}/></xml>)
+              M.fl M.css}
             {case M.icon of
                  None => <xml></xml>
                | Some icon => <xml><link rel="shortcut icon" href={icon} type="image/vnd.microsoft.icon"></link></xml>}
@@ -138,8 +141,10 @@ functor Make(M : THEME) = struct
         return <xml>
           <head>
             <title>{[titl]}</title>
-            <link rel="stylesheet" href={M.bootstrap}/>
-            <link rel="stylesheet" href={M.custom}/>
+            {@mapUX [url] [_]
+              (fn [nm ::_] [rest ::_] [_~_] url =>
+                  <xml><link rel="stylesheet" href={url}/></xml>)
+              M.fl M.css}
             {case M.icon of
                  None => <xml></xml>
                | Some icon => <xml><link rel="shortcut icon" href={icon} type="image/vnd.microsoft.icon"></link></xml>}

--- a/ui.urs
+++ b/ui.urs
@@ -51,12 +51,15 @@ val h4 : xbody -> t const
 val hr : t const
 
 (* Themes control where to get CSS and JavaScript from, etc. *)
+
 signature THEME = sig
-    val bootstrap : url
-    val custom : url
-    (* Two CSS URLs *)
-    val icon : option url
+    (* CSS URLs *)
+    con r :: {Unit}
+    val fl : folder r
+    val css : $(mapU url r)
+
     (* Shortcut icon *)
+    val icon : option url
 end
 
 functor Make(M : THEME) : sig


### PR DESCRIPTION
If I make a page with `Ui.simple` or `Ui.tabbed`, I want to be able to use my own stylesheets without breaking UPO's styling or having to copy content from UPO's stylesheet. This change to `Ui.THEME` makes extending given themes easy, like the following.

``` urweb
structure Theme = Ui.Make(struct
    val css = {MyApp = bless "/myApp/myStylesheet.css"} ++ Default.css
    val icon = Default.icon
end)
```
