### PR TITLE
In light of recent Ur/Web change, swap SQL ordering direction for queryL.

### DIFF
--- a/assignTasks.ur
+++ b/assignTasks.ur
@@ -35,7 +35,7 @@ functor Make(M : sig
                      Having = (WHERE TRUE),
                      SelectFields = sql_subset [[T = (assignable, _), Assignments = ([assigned = _], _)]],
                      SelectExps = {}}}}}
-                 ORDER BY {{{@Sql.order_by assignableFl (@Sql.some_fields [#T] [assignable] ! ! assignableFl) sql_desc}}})
+                 ORDER BY {{{@Sql.order_by assignableFl (@Sql.some_fields [#T] [assignable] ! ! assignableFl) sql_asc}}})
 
     val inj = @mp [sql_injectable_prim] [sql_injectable] @@sql_prim assignableFl inj_assignable
 
@@ -169,7 +169,7 @@ functor Make(M : sig
                                                                 </xml>) a.Eligible}
 
                                                                 <button class="btn btn-default"
-                                                                        onclick={fn _ => 
+                                                                        onclick={fn _ =>
                                                                                     us <- List.foldlM (fn (u, sel) ls =>
                                                                                                           b <- get sel;
                                                                                                           return (if b then u :: ls else ls)) [] ls;

--- a/chooseForeign.ur
+++ b/chooseForeign.ur
@@ -53,14 +53,14 @@ functor Make(M : sig
                               ! ! optionsConstInj optionsConstFl optionsConst}
                          ORDER BY {{{@Sql.order_by chosenFl
                             (@Sql.some_fields [#Options] [chosen] ! ! chosenFl)
-                           sql_desc}}});
+                           sql_asc}}});
         prefs <- queryL1 (SELECT choices.{{chosen}}
                           FROM choices
                           WHERE {@@Sql.easy_where [#Choices] [const ++ given] [_] [_] [_] [_]
                               ! ! (constInj ++ givenInj) (@Folder.concat ! constFl givenFl) (const ++ gv)}
                           ORDER BY {{{@Sql.order_by chosenFl
                             (@Sql.some_fields [#Choices] [chosen] ! ! chosenFl)
-                            sql_desc}}});
+                            sql_asc}}});
         prefs <- source prefs;
         toAdd <- source "";
         return {Given = gv, Options = opts, Prefs = prefs, ToAdd = toAdd}

--- a/finalGrades.ur
+++ b/finalGrades.ur
@@ -182,7 +182,7 @@ functor Make(M : sig
                          (@Folder.cons [#Grade] [_] ! fl) specialCase (key ++ {Grade = serialize g}));
         queryI1 (SELECT * FROM listeners)
                 (fn r => send r.Channel (SpecialCase (key, g)))
-        
+
     fun render' allRanges lastSm ranges (keys : list entry) =
         case keys of
             [] => <xml></xml>
@@ -408,7 +408,7 @@ functor Make(M : sig
     fun grades sms =
         ranges <- queryL1 (SELECT *
                            FROM ranges
-                           ORDER BY ranges.Min DESC, ranges.Max DESC);
+                           ORDER BY ranges.Min ASC, ranges.Max ASC);
 
         List.mapQuery ({{{sql_query1 [[]]
                         {Distinct = False,

--- a/grades.ur
+++ b/grades.ur
@@ -278,7 +278,7 @@ fun assignments [aks ::: {{Unit}}] [sks ::: {{Unit}}] [gks ::: {{Unit}}]
                                         FROM gra
                                         ORDER BY {{{@Sql.order_by fl
                                           (@Sql.some_fields [#Gra] [_] ! ! fl)
-                                          sql_asc}}});
+                                          sql_desc}}});
                          ats <- return (group ls None []);
                          len <- return (List.length ats);
                          return (ACategory (lab,

--- a/meetingGrid.ur
+++ b/meetingGrid.ur
@@ -331,7 +331,7 @@ functor Make(M : sig
                                      FROM time
                                      ORDER BY {{{@Sql.order_by timeKeyFl
                                        (@Sql.some_fields [#Time] [timeKey] ! ! timeKeyFl)
-                                       sql_desc}}});
+                                       sql_asc}}});
 
                 let
                     (* A bit of a little dance to initialize the meeting states,
@@ -427,7 +427,7 @@ functor Make(M : sig
                                        (usHardConst ++ usSoftConst)}
                                      ORDER BY {{{@Sql.order_by usFl
                                         (@Sql.some_fields [#Us] [usKey] ! ! usFl)
-                                        sql_desc}}});
+                                        sql_asc}}});
                     thems <- queryL1 (SELECT them.{{themKey}}
                                       FROM them
                                       WHERE {@@Sql.easy_where [#Them] [themHardConst ++ themSoftConst]
@@ -437,7 +437,7 @@ functor Make(M : sig
                                         (themHardConst ++ themSoftConst)}
                                       ORDER BY {{{@Sql.order_by themFl
                                         (@Sql.some_fields [#Them] [themKey] ! ! themFl)
-                                        sql_desc}}});
+                                        sql_asc}}});
                     unavails <- queryL1 (SELECT unavailable.{{usKey}}, unavailable.{{timeKey}}
                                          FROM unavailable JOIN us
                                            ON {@@Sql.easy_join [#Unavailable] [#Us]
@@ -451,7 +451,7 @@ functor Make(M : sig
                                          ORDER BY {{{@Sql.order_by (@Folder.concat ! usFl timeKeyFl)
                                            (@Sql.some_fields [#Unavailable] [usKey ++ timeKey] ! !
                                              (@Folder.concat ! usFl timeKeyFl))
-                                           sql_desc}}});
+                                           sql_asc}}});
                     meetings <- queryL (SELECT meeting.{{usKey}}, meeting.{{timeKey}}, meeting.{{themKey}},
                                           (SELECT COUNT( * )
                                            FROM meeting AS ByThem
@@ -464,7 +464,7 @@ functor Make(M : sig
                                         FROM meeting
                                         ORDER BY {{{@Sql.order_by allFl
                                           (@Sql.some_fields [#Meeting] [all] ! ! allFl)
-                                          sql_desc}}});
+                                          sql_asc}}});
                     meetings <- List.mapM (fn (us, off, tms) =>
                                               tms' <- List.mapM (fn (tm, avail, ths) =>
                                                                     ths <- source ths;
@@ -756,7 +756,7 @@ functor Make(M : sig
                                          FROM time
                                          ORDER BY {{{@Sql.order_by timeKeyFl
                                            (@Sql.some_fields [#Time] [timeKey] ! ! timeKeyFl)
-                                           sql_desc}}});
+                                           sql_asc}}});
                     meetings <- queryL (SELECT meeting.{{timeKey}}, meeting.{{themKey}}, them.{{themOffice}}
                                         FROM meeting
                                           JOIN them ON {@@Sql.easy_join [#Meeting] [#Them] [themKey]
@@ -774,7 +774,7 @@ functor Make(M : sig
                                         ORDER BY {{{@Sql.order_by (@Folder.concat ! timeKeyFl themFl)
                                           (@Sql.some_fields [#Meeting] [timeKey ++ themKey] ! !
                                             (@Folder.concat ! timeKeyFl themFl))
-                                          sql_desc}}});
+                                          sql_asc}}});
                     meetings <- List.mapM (fn (tm, ths) =>
                                               ths <- source ths;
                                               return (tm, ths))

--- a/openBallot.ur
+++ b/openBallot.ur
@@ -156,7 +156,7 @@ functor Make(M : sig
                              ORDER BY {{{@Sql.order_by (@Folder.concat ! choiceKeyFl (@Folder.mp voterKeyFl))
                                           (@Sql.some_fields [#Choice] [choiceKey] ! ! choiceKeyFl
                                             ++ @Sql.some_fields [#Vote] [map option voterKey] ! ! (@Folder.mp voterKeyFl))
-                                          sql_asc}}});
+                                          sql_desc}}});
 
             choices <- doVotes votes [] None [];
             choices <- source choices;
@@ -383,7 +383,7 @@ functor Make(M : sig
                                               | _ => <xml/>}, with <i>{[count]}</i> vote{case count of
                                                                                              1 => <xml/>
                                                                                            | _ => <xml>s</xml>}:</h3>
-                         
+
                          {List.mapX (fn ch => <xml>{[ch]}<br/></xml>) choices}
                        </xml>}/>
     </xml>

--- a/review.ur
+++ b/review.ur
@@ -286,7 +286,7 @@ functor Make(M : sig
                                    <xml/>
                                else <xml>
                                  <hr/>
-          
+
                                  <h2>Add Review</h2>
 
                                  {@mapX3 [fn _ => string] [Widget.t'] [fn p => id * p.2] [body]
@@ -322,7 +322,7 @@ functor Make(M : sig
             queryL1 (SELECT *
                      FROM tab AS T
                      WHERE {e}
-                     ORDER BY T.When)
+                     ORDER BY T.When DESC)
 
         fun onload _ = return ()
 

--- a/rsvp2.ur
+++ b/rsvp2.ur
@@ -251,7 +251,7 @@ functor Make(M : sig
                                    FROM event
                                    ORDER BY {{{@Sql.order_by eventKeyFl
                                      (@Sql.some_fields [#Event] [eventKey] ! ! eventKeyFl)
-                                     sql_desc}}});
+                                     sql_asc}}});
                 homes <- queryL (SELECT homeRsvp.*, home.{{homeData}}, home.{{homeSensitiveData}}
                                  FROM homeRsvp
                                    JOIN home ON {@@Sql.easy_join [#HomeRsvp] [#Home] [homeKey]
@@ -260,7 +260,7 @@ functor Make(M : sig
                                  ORDER BY {{{@Sql.order_by (@Folder.concat ! eventKeyFl homeKeyFl)
                                     (@Sql.some_fields [#HomeRsvp] [eventKey ++ homeKey] ! !
                                      (@Folder.concat ! eventKeyFl homeKeyFl))
-                                    sql_desc}}});
+                                    sql_asc}}});
                 aways <- queryL (SELECT awayRsvp.*, away.{{awayData}}, away.{{awaySensitiveData}}
                                  FROM awayRsvp
                                    JOIN away ON {@@Sql.easy_join [#AwayRsvp] [#Away] [awayKey]
@@ -269,7 +269,7 @@ functor Make(M : sig
                                  ORDER BY {{{@Sql.order_by (@Folder.concat ! eventKeyFl awayKeyFl)
                                     (@Sql.some_fields [#AwayRsvp] [eventKey ++ awayKey] ! !
                                      (@Folder.concat ! eventKeyFl awayKeyFl))
-                                    sql_desc}}});
+                                    sql_asc}}});
                 events <- List.mapM (fn r =>
                                         homes <- source r.Home;
                                         aways <- source r.Away;
@@ -340,7 +340,7 @@ functor Make(M : sig
                                                                 <xml><th>{[label]}</th></xml>)
                                                             awayShownDataFl awayShownDataLabels}
                                                         </tr>
-                                                                               
+
                                                         {List.mapX (fn aw => <xml><tr>
                                                           <td>{[aw.Away]}</td>
                                                           {@mapX2 [show] [ident] [tr]
@@ -364,7 +364,7 @@ functor Make(M : sig
                                                                 <xml><th>{[label]}</th></xml>)
                                                             homeShownDataFl homeShownDataLabels}
                                                         </tr>
-                                                                               
+
                                                         {List.mapX (fn ho => <xml><tr>
                                                           <td>{[ho.Home]}</td>
                                                           {@mapX2 [show] [ident] [tr]

--- a/submission.ur
+++ b/submission.ur
@@ -207,7 +207,7 @@ functor Make(M : sig
                            FROM submission
                            WHERE {@@Sql.easy_where [#Submission] [key] [_] [_] [_] [_] ! ! keyInj' keyFl k}
                              AND submission.{ukey} = {[u]}
-                           ORDER BY submission.When);
+                           ORDER BY submission.When DESC);
             ls <- source ls;
 
             ch <- channel;
@@ -257,7 +257,7 @@ functor Make(M : sig
             ls <- queryL1 (SELECT submission.Filename, submission.When, submission.{ukey}
                            FROM submission
                            WHERE {@@Sql.easy_where [#Submission] [key] [_] [_] [_] [_] ! ! keyInj' keyFl k}
-                           ORDER BY submission.When);
+                           ORDER BY submission.When DESC);
             ls <- source ls;
 
             ch <- channel;
@@ -302,7 +302,7 @@ functor Make(M : sig
         val create =
             queryL1 (SELECT submission.{{key}}, submission.Filename, submission.When, submission.{ukey}
                      FROM submission
-                     ORDER BY {{{@Sql.order_by (@Folder.concat ! keyFl _) (@Sql.some_fields [#Submission] [key ++ [Filename = _]] ! ! (@Folder.concat ! keyFl _)) sql_desc}}})
+                     ORDER BY {{{@Sql.order_by (@Folder.concat ! keyFl _) (@Sql.some_fields [#Submission] [key ++ [Filename = _]] ! ! (@Folder.concat ! keyFl _)) sql_asc}}})
 
         fun onload _ = return ()
 

--- a/withComments.ur
+++ b/withComments.ur
@@ -151,7 +151,7 @@ functor Make(M : sig
                             ORDER BY {{{@Sql.order_by (@Folder.concat ! keyFl (@Folder.mp userFl))
                                          (@Sql.some_fields [#Q] [key] ! ! keyFl
                                            ++ @Sql.some_fields [#Comment] [map option user] ! ! (@Folder.mp userFl))
-                                         sql_desc}}});
+                                         sql_asc}}});
             ents <- setup ents [] None [];
             ents <- source ents;
 


### PR DESCRIPTION
I noticed the times in `MeetingGrid` were displayed backwards, so I swapped that order. I'm assuming all the other `queryL` uses also need flipping. (The Ur/Web commit that flipped `queryL` happened in July 2016, after the most recent UPO commit to master in February 2016.)

I only changed instances where queryL was used with an ordering specified inline (either `sql_asc`, `ASC`, `sql_desc`, or `DESC`). If there were cases where an ordering was passed as a parameter, I missed them.