### PR TITLE
allow header lines in CSV import

### DIFF
--- a/csv.ur
+++ b/csv.ur
@@ -28,26 +28,30 @@ fun csvFold [fs] [acc] (f : $fs -> acc -> acc)
                     f acc' acc
             end
 
-        fun loop input acc =
+        fun loop (header : int) input acc =
             case String.split input #"\n" of
                 None =>
                 (case input of
                      "" => acc
-                   | _ => doLine input acc)
+                   | _ => if header = 0
+                          then acc
+                          else doLine input acc)
               | Some (line, input) =>
-                loop input (doLine line acc)
+                if header = 0
+                then loop 0 input (doLine line acc)
+                else loop (header-1) input acc
     in
         loop
     end
 
 
 fun parse [fs] (injs : $(map sql_injectable fs)) (reads : $(map read fs)) (fl : folder fs)
-          (input : string) =
-    @csvFold (fn r acc => r :: acc) injs reads fl input []
+          (header : int) (input : string) =
+    @csvFold (fn r acc => r :: acc) injs reads fl header input []
 
 fun importTable [fs] [cs] (injs : $(map sql_injectable fs)) (reads : $(map read fs)) (fl : folder fs)
-                (tab : sql_table fs cs) (input : string) =
-    List.app (@Sql.easy_insert injs fl tab) (@parse injs reads fl input)
+                (tab : sql_table fs cs) (header : int) (input : string) =
+    List.app (@Sql.easy_insert injs fl tab) (@parse injs reads fl header input)
 
 open Bootstrap3
 

--- a/csv.ur
+++ b/csv.ur
@@ -34,8 +34,8 @@ fun csvFold [fs] [acc] (f : $fs -> acc -> acc)
                 (case input of
                      "" => acc
                    | _ => if header = 0
-                          then acc
-                          else doLine input acc)
+                          then doLine input acc
+                          else acc)
               | Some (line, input) =>
                 if header = 0
                 then loop 0 input (doLine line acc)

--- a/csv.urs
+++ b/csv.urs
@@ -3,11 +3,13 @@
 val importTable : fs ::: {Type} -> cs ::: {{Unit}}
                   -> $(map sql_injectable fs) -> $(map read fs) -> folder fs
                   -> sql_table fs cs
+                  -> int
                   -> string
                   -> transaction unit
 
 val parse : fs ::: {Type}
             -> $(map sql_injectable fs) -> $(map read fs) -> folder fs
+            -> int
             -> string
             -> list $fs
 

--- a/csv.urs
+++ b/csv.urs
@@ -3,13 +3,13 @@
 val importTable : fs ::: {Type} -> cs ::: {{Unit}}
                   -> $(map sql_injectable fs) -> $(map read fs) -> folder fs
                   -> sql_table fs cs
-                  -> int
+                  -> int (* the number of header lines to skip *)
                   -> string
                   -> transaction unit
 
 val parse : fs ::: {Type}
             -> $(map sql_injectable fs) -> $(map read fs) -> folder fs
-            -> int
+            -> int (* the number of header lines to skip *)
             -> string
             -> list $fs
 

--- a/examples/mg.ur
+++ b/examples/mg.ur
@@ -182,7 +182,7 @@ task initialize = fn () =>
          dml (INSERT INTO time (Hour, Minute, Description) VALUES (12, 00, 'noon'))
 
 
-val importHomes = Csv.importTable h
+val importHomes = Csv.importTable h 0
 
 open Bootstrap3
 


### PR DESCRIPTION
When using Csv.importTable with uploaded file content there is a chance for header lines above the CSV. This allows skipping over those header lines.